### PR TITLE
custom_data can be undefined

### DIFF
--- a/lemonsqueezy-webhooks/src/types.ts
+++ b/lemonsqueezy-webhooks/src/types.ts
@@ -23,7 +23,7 @@ export type WebhookPayload<CustomData = any> = {
             | SubscriptionInvoiceEventNames
             | OrderEventNames
             | LicenseKeyEventNames
-        custom_data: CustomData
+        custom_data?: CustomData
     }
     data: Subscription | SubscriptionInvoice | Order | LicenseKey
 }


### PR DESCRIPTION
Fixing the type to reflect that custom_data can be undefined when it wasn't passed at the beginning of the transacation.