### PR TITLE
Add support for returning results from webhook

### DIFF
--- a/lemonsqueezy-webhooks/package.json
+++ b/lemonsqueezy-webhooks/package.json
@@ -1,6 +1,6 @@
 {
     "name": "lemonsqueezy-webhooks",
-    "version": "0.1.2",
+    "version": "0.1.3",
     "description": "lemon-squeezy webhooks types and an utility functions to handle webhooks in Node.js",
     "main": "dist/index.js",
     "module": "esm/index.js",

--- a/lemonsqueezy-webhooks/src/index.ts
+++ b/lemonsqueezy-webhooks/src/index.ts
@@ -106,8 +106,12 @@ export async function whatwgWebhooksHandler<CustomData = any>({
         const eventName = payload.meta.event_name
         const customData = payload.meta.custom_data
 
-        await onData({ event_name: eventName, ...payload } as any)
-        return new Response(JSON.stringify({ message: 'Webhook received' }), {
+        const result = await onData({ event_name: eventName, ...payload } as any)
+        const responseBody: { message: string; result?: any } = { message: 'Webhook received' }
+        if (result !== undefined) {
+            responseBody.result = result
+        }
+        return new Response(JSON.stringify(responseBody), {
             status: 200,
             headers: { 'Content-Type': 'application/json' },
         })


### PR DESCRIPTION
The result returned from onData is currently ignored, this PR returns it as part of the response message for better observability